### PR TITLE
Add a small change to inline the image

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,9 @@ CodeSee helps development teams visually understand how your large scale codebas
 
 ## Get started with CodeSee
 
-![CodeSee button in browser](img/codesee_fab_in_browser.png){ align=right }
+<p class="block">
+  <img alt="CodeSee button in browser" src="img/codesee_fab_in_browser.png" align="right">
+</p>
 
 By integrating CodeSee with your app, you will be able to make and view recordings of the inner workings of your Javascript or Typescript application.
 
@@ -23,4 +25,4 @@ Once installed, whenever you run your app in development and view it in your bro
 - The CodeSee UI can be a little sluggish with larger recordings -- thanks for your patience! For the moment, we ask that you give our UI a second to process now and then. But fear not, we take performance very seriously and we're actively working on performance improvements.
 
 ## [Next step: Installing CodeSee](./installation)
-&nbsp;  
+&nbsp;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,3 @@
+.block {
+  display: block;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,14 +3,14 @@ nav:
   - Overview: index.md
   - Installation:
     - Installing CodeSee: installation.md
-    - → Create React App: setup-cra.md
-    - → Typescript without Babel: setup-typescript-without-babel.md
-    - → Next: setup-next.md
-    - → Nuxt: setup-nuxt.md
-    - → Storybook: setup-storybook.md
-    - → Gatsby: setup-gatsby.md
-    - → Ember: setup-ember.md
-    - → Generic setup: setup-generic.md
+    - Create React App: setup-cra.md
+    - Typescript without Babel: setup-typescript-without-babel.md
+    - Next: setup-next.md
+    - Nuxt: setup-nuxt.md
+    - Storybook: setup-storybook.md
+    - Gatsby: setup-gatsby.md
+    - Ember: setup-ember.md
+    - Generic setup: setup-generic.md
     - Configuration options: options.md
   - Advanced setup:
     - Running CodeSee locally: local.md


### PR DESCRIPTION
This aims to fix an issue in the deployed docs:
![image](https://user-images.githubusercontent.com/656318/115442428-483cfe80-a212-11eb-99a6-894da36f43cb.png)

The build process is adding a `flow-root` CSS declaration.

It should look like this:
![image](https://user-images.githubusercontent.com/656318/115442490-5d199200-a212-11eb-8fa3-7c078b48e420.png)
